### PR TITLE
Slight updates

### DIFF
--- a/src/providers/connection-provider.tsx
+++ b/src/providers/connection-provider.tsx
@@ -44,17 +44,18 @@ export const ConnectionProvider: React.FC<ConnectionProviderProps> = ({
 
     // Set up event listeners for connection updates
     useEffect(() => {
-        const unlistenLogIn = listen("sign_in", () => {
+        const unlistenSignIn = listen("sign_in", () => {
             console.log("Sign In event received");
-            fetchAccount(); // Fetch account on connection
+            fetchAccount(); // sign in on connection
         });
 
-        const unlistenConnect = listen("connect", () => {
+        const unlistenConnected = listen("connected", () => {
             console.log("Connected event received");
             setIsConnected(true);
+            fetchAccount(); // try to fetch account on connection
         });
 
-        const unlistenDisconnect = listen("disconnect", () => {
+        const unlistenDisconnected = listen("disconnected", () => {
             console.log("Disconnected event received");
             setIsConnected(false);
             setAccount(null); // Clear account on disconnection
@@ -62,9 +63,9 @@ export const ConnectionProvider: React.FC<ConnectionProviderProps> = ({
 
         // Clean up listeners on unmount
         return () => {
-            unlistenLogIn.then((unlisten) => unlisten());
-            unlistenConnect.then((unlisten) => unlisten());
-            unlistenDisconnect.then((unlisten) => unlisten());
+            unlistenSignIn.then((unlisten) => unlisten());
+            unlistenConnected.then((unlisten) => unlisten());
+            unlistenDisconnected.then((unlisten) => unlisten());
         };
     }, []);
 


### PR DESCRIPTION
Slight Updates and change log_in to sign_in

Also the following does not seem to be used anywhere, it also does not emit an event so can't be used in the frontend. Perhaps you plan to use it in the backend. Currently we are just changing the connection status if we get either connected or disconnected event in the frontend, and perhaps that might give us more control than a singular is_connected event anyway. Plus our frontend has an isConnected value that is generated by these two events so it's much the same.

```
#[tauri::command]
async fn is_connected(app: AppHandle) -> bool {
    let safe = app.try_state::<Mutex<Option<Safe>>>();
    safe.is_some() // state is managed
        && safe.unwrap().lock().await.as_ref().is_some() // option<safe> is some
}
```